### PR TITLE
fix(workflow): capture fixer exit code safely under bash -e

### DIFF
--- a/.github/workflows/seo-runtime.yml
+++ b/.github/workflows/seo-runtime.yml
@@ -143,8 +143,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python seo/fixer.py
-          FIXER_EXIT=$?
+          # Capture exit code without triggering bash -e on non-zero exits.
+          # Exit 0 = fixes written, Exit 2 = nothing to fix, Exit 1 = error.
+          FIXER_EXIT=0
+          python seo/fixer.py || FIXER_EXIT=$?
 
           if [ "$FIXER_EXIT" -eq 2 ]; then
             echo "No fixable issues this run — skipping PR creation."


### PR DESCRIPTION
Fixes "Run SEO Fixer and Create Fix PR" step failing with exit code 2.

**Root cause:** GitHub Actions runs every `run:` block with `bash -e`. When `python seo/fixer.py` exits 2 ("no fixes needed"), bash kills the step immediately — before `FIXER_EXIT=$?` executes.

**Fix:** `FIXER_EXIT=0; python seo/fixer.py || FIXER_EXIT=$?` — the `||` branch captures the non-zero exit without triggering `-e`, because the overall `||` expression succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcVeeY5Fc6f1cY85F5KEKv)_