### PR TITLE
fix: meta tags, misleading forecast, and PR notification email

### DIFF
--- a/.github/workflows/seo-runtime.yml
+++ b/.github/workflows/seo-runtime.yml
@@ -143,8 +143,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python seo/fixer.py
-          FIXER_EXIT=$?
+          # Capture exit code without triggering bash -e on non-zero exits.
+          # Exit 0 = fixes written, Exit 2 = nothing to fix, Exit 1 = error.
+          FIXER_EXIT=0
+          python seo/fixer.py || FIXER_EXIT=$?
 
           if [ "$FIXER_EXIT" -eq 2 ]; then
             echo "No fixable issues this run — skipping PR creation."

--- a/.github/workflows/seo-runtime.yml
+++ b/.github/workflows/seo-runtime.yml
@@ -180,13 +180,48 @@ jobs:
           git commit -m "fix(seo): auto-fixes from run #${{ github.run_number }} [seo-fixer]"
           git push -u origin "$BRANCH"
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "SEO Auto-Fix: Run #${{ github.run_number }}" \
             --body "$(cat seo/data/pr_body.txt)" \
             --base main \
-            --head "$BRANCH" \
-            && echo "PR created successfully." \
-            || echo "::warning::gh pr create failed — branch is pushed, create the PR manually from $BRANCH."
+            --head "$BRANCH" 2>&1) \
+            && echo "PR created: $PR_URL" \
+            || { echo "::warning::gh pr create failed — branch pushed, create PR manually from $BRANCH."; PR_URL=""; }
+
+          # Send PR notification email if PR was created
+          if [ -n "$PR_URL" ]; then
+            python3 -c "
+import os, sys
+sys.path.insert(0, 'seo')
+import emailer, memory
+runs = memory.load_runs()
+last = runs[-1] if runs else {}
+pr_url = '''$PR_URL'''
+pr_body = open('seo/data/pr_body.txt').read()
+html = f'''<!DOCTYPE html><html><head><meta charset=\"UTF-8\"></head>
+<body style=\"margin:0;padding:32px;background:#f1f5f9;font-family:-apple-system,sans-serif;\">
+<div style=\"max-width:640px;margin:0 auto;\">
+  <div style=\"background:linear-gradient(135deg,#0f172a,#1e3a5f);border-radius:14px;padding:28px;margin-bottom:20px;\">
+    <h1 style=\"color:#fff;margin:0 0 6px;font-size:20px;\">&#x2705; SEO Auto-Fix PR Created</h1>
+    <p style=\"color:#94a3b8;margin:0;font-size:13px;\">Run #{last.get('run_id','?')} &middot; Skill {last.get('skill_id','?')}/23 &middot; {last.get('skill_name','')}</p>
+  </div>
+  <div style=\"background:#fff;border:1px solid #e2e8f0;border-radius:12px;padding:22px;margin-bottom:16px;\">
+    <p style=\"margin:0 0 16px;font-size:14px;color:#1e293b;\">The SEO Auto-Fixer generated fixes and opened a pull request. <strong>Human review and manual merge required.</strong></p>
+    <a href=\"{pr_url}\" style=\"display:inline-block;background:#0284c7;color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;font-size:13px;\">&#x1F517; Review PR on GitHub</a>
+  </div>
+  <div style=\"background:#f8fafc;border:1px solid #e2e8f0;border-radius:12px;padding:18px;\">
+    <pre style=\"margin:0;font-size:11px;color:#475569;white-space:pre-wrap;font-family:monospace;\">{pr_body[:1200]}</pre>
+  </div>
+  <p style=\"text-align:center;color:#94a3b8;font-size:11px;margin-top:16px;\">SEO Runtime Bot 2.0 &middot; amulyagupta.in</p>
+</div></body></html>'''
+ok = emailer.send_report(
+    f'[SEO FIX PR] Auto-Fix Created — Run #{last.get(\"run_id\",\"?\")} | Review Required',
+    html,
+    f'SEO Auto-Fix PR created: {pr_url}\n\nReview and merge required.\n\n{pr_body[:500]}'
+)
+print('PR notification email sent.' if ok else 'PR notification email failed (non-fatal).')
+"
+          fi
 
           # Return to original branch so the dashboard-data commit step works on main
           git checkout "${{ github.ref_name }}"

--- a/amulya-gupta.html
+++ b/amulya-gupta.html
@@ -4,17 +4,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Amulya Gupta — AI Systems Engineer Profile</title>
-  <meta name="description" content="Amulya Gupta is an AI Systems Engineer specializing in agentic AI, LLM pipelines, RAG systems, and production ML infrastructure. BITS Pilani. Official website: amulyagupta.in" />
+  <meta name="description" content="Amulya Gupta — AI Systems Engineer specializing in agentic AI, LLM pipelines, RAG systems, and production ML infrastructure. M.Tech AI/ML, BITS Pilani." />
   <meta name="author" content="Amulya Gupta" />
   <meta property="og:title" content="Amulya Gupta | AI Systems Engineer" />
-  <meta property="og:description" content="AI Systems Engineer specializing in agentic AI, LLM pipelines, and production ML infrastructure." />
+  <meta property="og:description" content="Amulya Gupta — AI Systems Engineer specializing in agentic AI, LLM pipelines, RAG systems, and production ML infrastructure. M.Tech AI/ML, BITS Pilani." />
   <meta property="og:url" content="https://amulyagupta.in/amulya-gupta.html" />
   <meta property="og:type" content="profile" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Amulya Gupta | AI Systems Engineer" />
-  <meta name="twitter:description" content="AI Systems Engineer specializing in agentic AI, LLM pipelines, and production ML infrastructure." />
+  <meta name="twitter:description" content="Amulya Gupta — AI Systems Engineer specializing in agentic AI, LLM pipelines, RAG systems, and production ML infrastructure. M.Tech AI/ML, BITS Pilani." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/blog/ai-ml-guide-2026.html
+++ b/blog/ai-ml-guide-2026.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>AI/ML Roadmap 2026: From Zero to Job-Ready Without a Degree | Amulya Gupta</title>
-  <meta name="description" content="A friend asked me how to break into AI without a degree. I built them a complete guide — 6 phases, free courses, honest 12-month plan, ₹12–16k max spend. No fluff, no upsells." />
-  <meta property="og:title" content="AI/ML Roadmap 2026: From Zero to Job-Ready Without a Degree" />
-  <meta property="og:description" content="6 phases, free courses, honest 12-month plan, ₹12–16k max spend. No fluff, no upsells." />
+  <title>AI/ML Roadmap 2026: From Zero to Job-Ready | Amulya Gupta</title>
+  <meta name="description" content="How to break into AI without a degree — 6 phases, free courses, honest 12-month plan, under ₹16k budget. No fluff, no upsells, just what works." />
+  <meta property="og:title" content="AI/ML Roadmap 2026: From Zero to Job-Ready | Amulya Gupta" />
+  <meta property="og:description" content="How to break into AI without a degree — 6 phases, free courses, honest 12-month plan, under ₹16k budget. No fluff, no upsells, just what works." />
   <meta property="og:url" content="https://amulyagupta.in/blog/ai-ml-guide-2026.html" />
   <meta property="og:type" content="article" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="AI/ML Roadmap 2026: From Zero to Job-Ready Without a Degree" />
-  <meta name="twitter:description" content="6 phases, free courses, honest 12-month plan, ₹12–16k max spend." />
+  <meta name="twitter:title" content="AI/ML Roadmap 2026: From Zero to Job-Ready | Amulya Gupta" />
+  <meta name="twitter:description" content="How to break into AI without a degree — 6 phases, free courses, honest 12-month plan, under ₹16k budget. No fluff, no upsells, just what works." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Blog | Amulya Gupta — AI Systems, Agentic AI, LLM &amp; MLOps Engineering</title>
-  <meta name="description" content="Technical writing on AI systems, agentic AI, RAG pipelines, MLOps, and production ML engineering by Amulya Gupta." />
-  <meta property="og:title" content="Blog | Amulya Gupta — AI Systems & Agentic AI" />
-  <meta property="og:description" content="Technical writing on AI systems, agentic AI, RAG pipelines, and MLOps by Amulya Gupta." />
+  <title>Blog | Amulya Gupta — AI, Agentic AI &amp; MLOps</title>
+  <meta name="description" content="Technical writing on AI systems, agentic AI, RAG pipelines, LLM workflows, and production ML engineering by Amulya Gupta — BITS Pilani M.Tech." />
+  <meta property="og:title" content="Blog | Amulya Gupta — AI, Agentic AI &amp; MLOps" />
+  <meta property="og:description" content="Technical writing on AI systems, agentic AI, RAG pipelines, LLM workflows, and production ML engineering by Amulya Gupta — BITS Pilani M.Tech." />
   <meta property="og:url" content="https://amulyagupta.in/blog/index.html" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Blog | Amulya Gupta — AI Systems & Agentic AI" />
-  <meta name="twitter:description" content="Technical writing on AI systems, agentic AI, RAG pipelines, and MLOps by Amulya Gupta." />
+  <meta name="twitter:title" content="Blog | Amulya Gupta — AI, Agentic AI &amp; MLOps" />
+  <meta name="twitter:description" content="Technical writing on AI systems, agentic AI, RAG pipelines, LLM workflows, and production ML engineering by Amulya Gupta — BITS Pilani M.Tech." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/blog/post-1-mlops-pipeline.html
+++ b/blog/post-1-mlops-pipeline.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>How I Built an End-to-End MLOps Pipeline: MLflow + FastAPI + Kubernetes | Amulya Gupta</title>
-  <meta name="description" content="A complete walkthrough of building a production MLOps pipeline — from MLflow experiment tracking to FastAPI inference to Kubernetes deployment with Prometheus/Grafana observability." />
-  <meta property="og:title" content="End-to-End MLOps Pipeline: MLflow + FastAPI + Kubernetes" />
-  <meta property="og:description" content="A complete walkthrough of building a production MLOps pipeline by Amulya Gupta." />
+  <title>Building an MLOps Pipeline: MLflow, FastAPI, Kubernetes</title>
+  <meta name="description" content="A production MLOps pipeline walkthrough — MLflow experiment tracking, FastAPI inference, Kubernetes deployment, and Prometheus/Grafana observability." />
+  <meta property="og:title" content="Building an MLOps Pipeline: MLflow, FastAPI, Kubernetes" />
+  <meta property="og:description" content="A production MLOps pipeline walkthrough — MLflow experiment tracking, FastAPI inference, Kubernetes deployment, and Prometheus/Grafana observability." />
   <meta property="og:url" content="https://amulyagupta.in/blog/post-1-mlops-pipeline.html" />
   <meta property="og:type" content="article" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="End-to-End MLOps Pipeline: MLflow + FastAPI + Kubernetes" />
-  <meta name="twitter:description" content="A complete walkthrough of building a production MLOps pipeline by Amulya Gupta." />
+  <meta name="twitter:title" content="Building an MLOps Pipeline: MLflow, FastAPI, Kubernetes" />
+  <meta name="twitter:description" content="A production MLOps pipeline walkthrough — MLflow experiment tracking, FastAPI inference, Kubernetes deployment, and Prometheus/Grafana observability." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/blog/post-2-mlops-stack.html
+++ b/blog/post-2-mlops-stack.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MLOps in 2025: The Stack I Actually Use (and Why) | Amulya Gupta</title>
-  <meta name="description" content="The opinionated MLOps stack I've settled on — MLflow, Prefect, FastAPI, Docker, Kubernetes, Prometheus, Grafana, and GitHub Actions — and why each one earned its place." />
-  <meta property="og:title" content="MLOps in 2025: The Stack I Actually Use" />
-  <meta property="og:description" content="The opinionated MLOps stack I've settled on and why each tool earned its place, by Amulya Gupta." />
+  <title>MLOps Stack 2025: What I Actually Use | Amulya Gupta</title>
+  <meta name="description" content="The MLOps stack I've settled on — MLflow, Prefect, FastAPI, Docker, Kubernetes, Prometheus, Grafana, and GitHub Actions — and why each earned its place." />
+  <meta property="og:title" content="MLOps Stack 2025: What I Actually Use | Amulya Gupta" />
+  <meta property="og:description" content="The MLOps stack I've settled on — MLflow, Prefect, FastAPI, Docker, Kubernetes, Prometheus, Grafana, and GitHub Actions — and why each earned its place." />
   <meta property="og:url" content="https://amulyagupta.in/blog/post-2-mlops-stack.html" />
   <meta property="og:type" content="article" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="MLOps in 2025: The Stack I Actually Use" />
-  <meta name="twitter:description" content="The opinionated MLOps stack I've settled on and why each tool earned its place, by Amulya Gupta." />
+  <meta name="twitter:title" content="MLOps Stack 2025: What I Actually Use | Amulya Gupta" />
+  <meta name="twitter:description" content="The MLOps stack I've settled on — MLflow, Prefect, FastAPI, Docker, Kubernetes, Prometheus, Grafana, and GitHub Actions — and why each earned its place." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Contact Amulya Gupta | AI Systems Engineer | Agentic AI · LLM · MLOps</title>
+  <title>Contact Amulya Gupta | AI Systems Engineer</title>
   <meta name="description" content="Get in touch with Amulya Gupta — AI Systems Engineer based in Noida, India. Open to AI systems, agentic AI, and production ML roles." />
   <meta property="og:title" content="Contact Amulya Gupta | AI Systems Engineer" />
   <meta property="og:description" content="Open to AI systems engineering, agentic AI, and production ML roles. Available for full-time and consulting." />

--- a/experience.html
+++ b/experience.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Experience | Amulya Gupta — AI Systems Engineer | HCLTech · Classplus · BITS Pilani</title>
+  <title>Experience | Amulya Gupta — AI Systems Engineer</title>
   <meta name="description" content="3+ years building AI systems, production ML infrastructure, and scalable backends at HCLTech and Classplus. M.Tech AI/ML at BITS Pilani." />
   <meta property="og:title" content="Experience | Amulya Gupta — AI Systems Engineer" />
   <meta property="og:description" content="3+ years building AI systems and production ML infrastructure at HCLTech and Classplus. M.Tech AI/ML at BITS Pilani." />

--- a/index.html
+++ b/index.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Amulya Gupta | AI Systems Engineer | Agentic AI · LLM · MLOps</title>
-  <meta name="description" content="AI Systems Engineer building agentic AI workflows, LLM pipelines, RAG systems, and production ML infrastructure. 3+ years shipping scalable AI systems. BITS Pilani M.Tech AI/ML." />
+  <title>Amulya Gupta | AI Systems &amp; Agentic AI Engineer</title>
+  <meta name="description" content="AI Systems Engineer building agentic AI workflows, LLM pipelines, and production ML infrastructure. 3+ years shipping scalable AI systems. BITS Pilani." />
   <meta name="keywords" content="AI systems engineer, agentic AI, LLM pipelines, RAG, MLOps, production ML, FastAPI, Docker, Kubernetes, BITS Pilani, HCLTech" />
   <meta name="author" content="Amulya Gupta" />
   <!-- Open Graph -->
-  <meta property="og:title" content="Amulya Gupta | AI Systems Engineer — Agentic AI · LLM · MLOps" />
-  <meta property="og:description" content="Building agentic AI workflows, LLM pipelines, and production ML infrastructure that actually ships." />
+  <meta property="og:title" content="Amulya Gupta | AI Systems &amp; Agentic AI Engineer" />
+  <meta property="og:description" content="AI Systems Engineer building agentic AI workflows, LLM pipelines, and production ML infrastructure. 3+ years shipping scalable AI systems." />
   <meta property="og:url" content="https://amulyagupta.in/" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Amulya Gupta | AI Systems Engineer — Agentic AI · LLM · MLOps" />
-  <meta name="twitter:description" content="Building agentic AI workflows, LLM pipelines, and production ML infrastructure that actually ships." />
+  <meta name="twitter:title" content="Amulya Gupta | AI Systems &amp; Agentic AI Engineer" />
+  <meta name="twitter:description" content="AI Systems Engineer building agentic AI workflows, LLM pipelines, and production ML infrastructure. 3+ years shipping scalable AI systems." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Privacy Policy | Amulya Gupta — AI Systems Engineer</title>
-  <meta name="description" content="Privacy policy for amulyagupta.in — what data is collected, how it is used, and your rights as a visitor." />
+  <meta name="description" content="Privacy policy for amulyagupta.in — what data is collected, how it is used, your rights as a visitor, and how to contact us with any questions." />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
   <script>

--- a/projects.html
+++ b/projects.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Projects | Amulya Gupta — AI &amp; MLOps Engineer</title>
-  <meta name="description" content="AI systems built by Amulya Gupta: agentic AI workflows, RAG pipelines, end-to-end MLOps systems, and production ML infrastructure with full architecture documentation." />
+  <meta name="description" content="AI systems by Amulya Gupta: agentic AI workflows, RAG pipelines, end-to-end MLOps, and production ML infrastructure with full architecture documentation." />
   <meta property="og:title" content="AI Systems & Projects | Amulya Gupta" />
-  <meta property="og:description" content="Agentic AI, RAG pipelines, MLOps systems, and production ML infrastructure." />
+  <meta property="og:description" content="AI systems by Amulya Gupta: agentic AI workflows, RAG pipelines, end-to-end MLOps, and production ML infrastructure with full architecture documentation." />
   <meta property="og:url" content="https://amulyagupta.in/projects.html" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="AI Systems & Projects | Amulya Gupta" />
-  <meta name="twitter:description" content="Agentic AI, RAG pipelines, MLOps systems, and production ML infrastructure." />
+  <meta name="twitter:description" content="AI systems by Amulya Gupta: agentic AI workflows, RAG pipelines, end-to-end MLOps, and production ML infrastructure with full architecture documentation." />
   <meta name="twitter:image" content="https://github.com/amulyagupta1278.png" />
   <!-- Security Headers -->
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/seo/emailer.py
+++ b/seo/emailer.py
@@ -203,11 +203,32 @@ def _build_historical_comparison_section(comparison: dict) -> str:
 
 
 def _build_predictive_forecast_section(forecast: dict) -> str:
-    if not forecast or forecast.get("trend") == "insufficient_data":
+    # Guard: first cycle has no valid cross-skill trend
+    if not forecast or forecast.get("trend") in ("insufficient_data", "first_cycle_in_progress"):
+        cycle_status = forecast.get("cycle_status", "") if forecast else ""
+        cycle_msg = f"<br><span style='color:#0369a1;font-weight:600'>{cycle_status}</span>" if cycle_status else ""
+        lowest = forecast.get("lowest_scoring_skills", []) if forecast else []
+        lowest_html = ""
+        if lowest:
+            from config import SKILL_NAMES as _NAMES
+            items = []
+            for sid, sc in lowest:
+                name = _NAMES[int(sid) - 1] if 1 <= int(sid) <= 23 else f"Skill {sid}"
+                items.append(f"<li style='margin:3px 0;font-size:12px'>{name}: <strong style='color:#dc2626'>{sc}/100</strong></li>")
+            lowest_html = f"<p style='font-weight:600;font-size:12px;color:#0369a1;margin:10px 0 4px'>Priority skills to improve:</p><ul style='margin:0;padding-left:18px'>{''.join(items)}</ul>"
+        return f"""<div class="forecast-block">
+          <div class="card-title" style="color:#0369a1">SEO Forecast</div>
+          <p style="color:#0c4a6e;font-size:13px">
+            Trend analysis requires the same skill to be audited at least twice (cycle 2+).
+            Cross-skill score comparisons are not a valid trend signal.{cycle_msg}
+          </p>
+          {lowest_html}
+        </div>"""
+
+    if not forecast:
         return """<div class="forecast-block">
           <div class="card-title" style="color:#0369a1">Predictive SEO Forecast</div>
-          <p style="color:#0c4a6e;font-size:13px">Insufficient data for forecasting.
-          Projections will appear after 3+ skill runs.</p>
+          <p style="color:#0c4a6e;font-size:13px">No forecast data available yet.</p>
         </div>"""
 
     trend = forecast.get("trend", "stable")

--- a/seo/memory.py
+++ b/seo/memory.py
@@ -252,60 +252,70 @@ def detect_recurring_issues(issues: dict) -> list[dict]:
 
 def build_predictive_forecast(scores: list) -> dict:
     """
-    Simple linear trend forecast for overall SEO health score.
-    Uses the last 23 data points (one full cycle).
+    Linear trend forecast — only meaningful with multi-cycle data.
+    During cycle 1 (each skill run once), returns first_cycle_in_progress
+    to prevent misleading trends from cross-skill score comparisons.
     """
-    recent = scores[-23:] if len(scores) >= 23 else scores
-    if len(recent) < 3:
+    if not scores:
+        return {"trend": "insufficient_data", "projected_score_7d": None,
+                "projected_score_30d": None, "confidence": "low",
+                "momentum": "neutral", "risk_level": "unknown", "data_points": 0}
+
+    # Determine if any skill has been run more than once (multi-cycle data)
+    from collections import Counter
+    skill_counts = Counter(s.get("skill_id") for s in scores if s.get("skill_id"))
+    has_multi_cycle = any(v >= 2 for v in skill_counts.values())
+    n = len(scores)
+
+    # Always compute lowest-scoring skills — this is always accurate
+    score_by_skill = {}
+    for s in scores:
+        sid = s.get("skill_id")
+        if sid:
+            score_by_skill[sid] = s["score"]
+    lowest_skills = sorted(score_by_skill.items(), key=lambda x: x[1])[:3]
+    highest_skills = sorted(score_by_skill.items(), key=lambda x: x[1], reverse=True)[:3]
+
+    if not has_multi_cycle:
+        # First cycle in progress — cross-skill regression is not a valid trend
         return {
-            "trend": "insufficient_data",
+            "trend": "first_cycle_in_progress",
             "projected_score_7d": None,
             "projected_score_30d": None,
             "confidence": "low",
             "momentum": "neutral",
-            "risk_level": "unknown",
+            "risk_level": "low",
+            "data_points": n,
+            "cycle_status": f"Cycle 1 in progress — {n}/23 skills run",
+            "lowest_scoring_skills": lowest_skills,
+            "highest_scoring_skills": highest_skills,
         }
 
-    score_vals = [s["score"] for s in recent]
-    n = len(score_vals)
+    # Multi-cycle: compute trend from same-skill deltas
+    skill_deltas = []
+    for sid, count in skill_counts.items():
+        if count >= 2:
+            skill_scores = [s["score"] for s in scores if s.get("skill_id") == sid]
+            skill_deltas.append(skill_scores[-1] - skill_scores[-2])
 
-    # Linear regression
-    x_mean = (n - 1) / 2
-    y_mean = sum(score_vals) / n
-    numerator = sum((i - x_mean) * (score_vals[i] - y_mean) for i in range(n))
-    denominator = sum((i - x_mean) ** 2 for i in range(n))
-    slope = numerator / denominator if denominator else 0
-
-    current = score_vals[-1]
-    projected_7d = min(100, max(0, round(current + slope * 7, 1)))
-    projected_30d = min(100, max(0, round(current + slope * 30, 1)))
-
-    # Momentum: average of last 5 deltas
-    deltas = [score_vals[i] - score_vals[i - 1] for i in range(1, len(score_vals))]
-    recent_deltas = deltas[-5:] if len(deltas) >= 5 else deltas
-    avg_delta = sum(recent_deltas) / len(recent_deltas) if recent_deltas else 0
-
+    avg_delta = sum(skill_deltas) / len(skill_deltas) if skill_deltas else 0
+    trend = "improving" if avg_delta > 1 else "declining" if avg_delta < -1 else "stable"
     momentum = "positive" if avg_delta > 1 else "negative" if avg_delta < -1 else "neutral"
-    trend = "improving" if slope > 0.2 else "declining" if slope < -0.2 else "stable"
-    confidence = "high" if n >= 20 else "medium" if n >= 10 else "low"
 
-    # Risk level
-    critical_ratio = sum(1 for s in recent if s["score"] < 50) / n
+    recent_scores = scores[-23:]
+    score_vals = [s["score"] for s in recent_scores]
+    current = score_vals[-1]
+    projected_7d = min(100, max(0, round(current + avg_delta * 7, 1)))
+    projected_30d = min(100, max(0, round(current + avg_delta * 30, 1)))
+
+    cycles_complete = max(skill_counts.values())
+    confidence = "high" if cycles_complete >= 3 else "medium" if cycles_complete >= 2 else "low"
+    critical_ratio = sum(1 for s in recent_scores if s["score"] < 50) / len(recent_scores)
     risk_level = "high" if critical_ratio > 0.3 else "medium" if critical_ratio > 0.1 else "low"
-
-    # Category scores if available
-    score_by_category = {}
-    for s in recent:
-        sid = s.get("skill_id")
-        if sid:
-            score_by_category[sid] = s["score"]
-
-    lowest_skills = sorted(score_by_category.items(), key=lambda x: x[1])[:3]
-    highest_skills = sorted(score_by_category.items(), key=lambda x: x[1], reverse=True)[:3]
 
     return {
         "trend": trend,
-        "slope_per_day": round(slope, 3),
+        "slope_per_day": round(avg_delta / 23, 3),
         "current_score": current,
         "projected_score_7d": projected_7d,
         "projected_score_30d": projected_30d,


### PR DESCRIPTION
## What this fixes

### 1. Meta Tags & Open Graph — Skill 6 was scoring 5/100
- **7 pages had titles >60 chars** (truncated in Google SERPs): index, experience, contact, blog/index, post-1, post-2, ai-ml-guide-2026
- **6 pages had descriptions >160 chars** (truncated in search previews): index, projects, amulya-gupta, post-1, post-2, ai-ml-guide-2026
- **2 pages had descriptions <120 chars** (too short to rank well): blog/index, privacy
- All og:title, og:description, twitter:title, twitter:description updated to match

### 2. Misleading "DECLINING" forecast in emails
The weekly email showed DECLINING with -19 pts/day. This was a **false signal** — the code was running linear regression across scores from 6 *different skills* (crawl=100 → meta=5), treating them as a time series. That's comparing apples to oranges, not measuring actual improvement or decline.

**Fix:** Forecast is now suppressed during cycle 1. It will only compute a real trend once the same skill has been run twice (cycle 2+). Until then, emails show "Cycle 1 in progress — X/23 skills run" with the list of lowest-scoring skills to focus on.

### 3. PR notification email
When the auto-fixer creates a PR, you now immediately receive an email with the PR link, a summary of what was fixed, and a review button — so you know exactly when something is waiting for your approval.

## Test plan
- [ ] Run Skill 6 (Meta Tags) again — expect score to jump from 5/100 to 70+/100
- [ ] Confirm weekly email shows "Cycle 1 in progress" instead of DECLINING
- [ ] Trigger a run that produces fixes and verify PR notification email arrives

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcVeeY5Fc6f1cY85F5KEKv)_