### PR TITLE
fix(runtime): fix NameError crash + protect reporting layer from uncaught exceptions

### DIFF
--- a/seo/memory.py
+++ b/seo/memory.py
@@ -474,16 +474,6 @@ def build_cwv_summary(findings: list) -> dict:
                         cwv[metric].append(float(val))
                     except (TypeError, ValueError):
                         pass
-            if meta:
-                cwv["records"].append({
-                    "url": f.get("url", ""),
-                    "strategy": meta.get("strategy", "mobile"),
-                    "lcp_ms": meta.get("lcp"),
-                    "cls": meta.get("cls"),
-                    "fid_ms": meta.get("fid"),
-                    "inp_ms": meta.get("inp"),
-                    "ttfb_ms": meta.get("ttfb"),
-                })
     return {
         "lcp_avg": round(sum(cwv["lcp"]) / len(cwv["lcp"]), 0) if cwv["lcp"] else None,
         "cls_avg": round(sum(cwv["cls"]) / len(cwv["cls"]), 3) if cwv["cls"] else None,

--- a/seo/runtime.py
+++ b/seo/runtime.py
@@ -485,21 +485,26 @@ def run() -> None:
 
     # ── Email report — Humaniser layer (post-execution only) ─────────────────
     governance.assert_humaniser_scope("emailer.build_morning_brief")
-    html, text = emailer.build_morning_brief(
-        run_record, findings_dicts, skill_name, result.score,
-        comparison=comparison,
-        forecast=forecast,
-        cycle_progress=cycle_progress,
-        recurring=recurring,
-    )
-    status_icon = "✓" if result.score >= 80 else "⚠" if result.score >= 50 else "✗"
-    subject = (
-        f"[SEO {status_icon}] Skill {skill_id:02d}/23 — {skill_name} | "
-        f"Score {result.score}/100 | {now.strftime('%b %d')}"
-    )
-    if result.critical_count > 0:
-        subject = "[SEO CRITICAL] " + subject.split("] ", 1)[-1]
-    email_ok = emailer.send_report(subject, html, text)
+    try:
+        html, text = emailer.build_morning_brief(
+            run_record, findings_dicts, skill_name, result.score,
+            comparison=comparison,
+            forecast=forecast,
+            cycle_progress=cycle_progress,
+            recurring=recurring,
+        )
+        status_icon = "✓" if result.score >= 80 else "⚠" if result.score >= 50 else "✗"
+        subject = (
+            f"[SEO {status_icon}] Skill {skill_id:02d}/23 — {skill_name} | "
+            f"Score {result.score}/100 | {now.strftime('%b %d')}"
+        )
+        if result.critical_count > 0:
+            subject = "[SEO CRITICAL] " + subject.split("] ", 1)[-1]
+        email_ok = emailer.send_report(subject, html, text)
+    except Exception as e:
+        log.error("Morning brief email failed (non-fatal): %s\n%s", e, traceback.format_exc())
+        email_ok = False
+        subject = f"[SEO] Skill {skill_id:02d}/23 email build error"
     sheets.append("seo_emails", [
         now.isoformat(), config.REPORT_EMAIL, subject,
         "sent" if email_ok else "failed",
@@ -522,8 +527,11 @@ def run() -> None:
 
     # ── Dashboard snapshot (after email log is finalized) ─────────────────────
     issues = memory.load_issues()  # reload — email log now written
-    snapshot = memory.build_dashboard_snapshot(run_record, findings_dicts, scores, issues)
-    log.info("Dashboard snapshot written")
+    try:
+        snapshot = memory.build_dashboard_snapshot(run_record, findings_dicts, scores, issues)
+        log.info("Dashboard snapshot written")
+    except Exception as e:
+        log.error("Dashboard snapshot failed (non-fatal): %s\n%s", e, traceback.format_exc())
 
     # ── Save state ───────────────────────────────────────────────────────────
     memory.save_run_state(skill_id, run_id)


### PR DESCRIPTION
## Summary

Today's automated SEO run (Run #49, June 13) failed. Root cause investigation identified two bugs that can crash the runtime and cause the GitHub Actions job to fail:

### Bug 1 — `NameError: name 'meta' is not defined` in `build_cwv_summary` (`memory.py`)

The `build_cwv_summary()` function referenced an undefined variable `meta` inside the `if cat == "cwv":` branch. This causes an unhandled `NameError` crash whenever any skill produces a finding with `category="cwv"` (skill 5 — Core Web Vitals).

**Fix:** Removed the dead `if meta:` block. CWV records are already tracked correctly via `result.metadata["cwv_records"]` → the `seo_cwv` Sheets tab in `runtime.py`.

### Bug 2 — `build_morning_brief()` and `build_dashboard_snapshot()` not protected by try/except (`runtime.py`)

Both calls were outside any try/except. An uncaught exception in either would:
- Exit the runtime with code 1, failing the GitHub Actions job
- Skip `memory.save_run_state()`, causing the **same skill to re-run the next day** instead of advancing the rotation

**Fix:** Both calls are now wrapped in try/except so reporting failures are logged as errors but are non-fatal. The skill rotation state is always saved after successful execution.

## Impact

- Without this fix, skill 5 (Core Web Vitals) would crash every time `PAGESPEED_API_KEY` is set and LCP/CLS thresholds are exceeded
- Any future exception in the email/dashboard reporting layer would silently break the 23-day skill rotation cycle

## Test Plan

- [x] `build_cwv_summary([])` → no crash
- [x] `build_cwv_summary([{"category": "cwv", "lcp": 3000, ...}])` → no crash, correct output
- [x] `build_cwv_summary([{"category": "performance", ...}])` → no crash

## Action Required After Merge

Re-trigger today's failed SEO skill run manually:
1. Go to **Actions → SEO Autonomous Runtime → Run workflow**
2. Set `skill_override` to `auto` (or `15` if Skill 15 — Page Speed Deep Dive is confirmed next)
3. Click **Run workflow**

https://claude.ai/code/session_01Xjx9RbwV5BKYfJudPJDyry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjx9RbwV5BKYfJudPJDyry)_