### PR TITLE
fix(runtime): NameError crash fix + reporting protection + issue auto-resolution

### DIFF
--- a/seo/memory.py
+++ b/seo/memory.py
@@ -125,6 +125,31 @@ def batch_upsert_issues(skill_id: int, findings: list) -> list:
     return results
 
 
+def resolve_stale_issues(skill_id: int, new_findings: list[dict]) -> list[str]:
+    """Mark active issues from this skill as resolved if they didn't reappear.
+
+    Called after batch_upsert_issues so the same load/save cycle is distinct.
+    Returns list of resolved issue IDs for logging.
+    """
+    issues = load_issues()
+    new_ids = {
+        make_issue_id(skill_id, f.get("category", ""), f.get("url", ""), f.get("title", ""))
+        for f in new_findings
+    }
+    now = datetime.utcnow().isoformat()
+    resolved = []
+    for iid, issue in issues.items():
+        if (issue.get("skill_id") == skill_id
+                and issue.get("status") == "active"
+                and iid not in new_ids):
+            issues[iid]["status"] = "resolved"
+            issues[iid]["last_seen"] = now
+            resolved.append(iid)
+    if resolved:
+        save_issues(issues)
+    return resolved
+
+
 def load_score_history() -> list:
     return load_json("scores.json", [])
 
@@ -474,16 +499,6 @@ def build_cwv_summary(findings: list) -> dict:
                         cwv[metric].append(float(val))
                     except (TypeError, ValueError):
                         pass
-            if meta:
-                cwv["records"].append({
-                    "url": f.get("url", ""),
-                    "strategy": meta.get("strategy", "mobile"),
-                    "lcp_ms": meta.get("lcp"),
-                    "cls": meta.get("cls"),
-                    "fid_ms": meta.get("fid"),
-                    "inp_ms": meta.get("inp"),
-                    "ttfb_ms": meta.get("ttfb"),
-                })
     return {
         "lcp_avg": round(sum(cwv["lcp"]) / len(cwv["lcp"]), 0) if cwv["lcp"] else None,
         "cls_avg": round(sum(cwv["cls"]) / len(cwv["cls"]), 3) if cwv["cls"] else None,

--- a/seo/runtime.py
+++ b/seo/runtime.py
@@ -361,6 +361,14 @@ def run() -> None:
             except Exception as e2:
                 log.warning("Failed to persist finding: %s", e2)
 
+    # ── Auto-resolve stale issues — issues from this skill that didn't reappear ─
+    try:
+        resolved_ids = memory.resolve_stale_issues(skill_id, findings_dicts)
+        if resolved_ids:
+            log.info("Auto-resolved %d stale issue(s) from skill %d", len(resolved_ids), skill_id)
+    except Exception as e:
+        log.warning("resolve_stale_issues failed (non-fatal): %s", e)
+
     for issue, finding in zip(upserted, findings_dicts):
         try:
             sheets.append("seo_issues", [
@@ -484,29 +492,29 @@ def run() -> None:
             log.warning("Critical alert email failed: %s", e)
 
     # ── Email report — Humaniser layer (post-execution only) ─────────────────
-    governance.assert_humaniser_scope("emailer.build_morning_brief")
-    html, text = emailer.build_morning_brief(
-        run_record, findings_dicts, skill_name, result.score,
-        comparison=comparison,
-        forecast=forecast,
-        cycle_progress=cycle_progress,
-        recurring=recurring,
-    )
-    status_icon = "✓" if result.score >= 80 else "⚠" if result.score >= 50 else "✗"
-    subject = (
-        f"[SEO {status_icon}] Skill {skill_id:02d}/23 — {skill_name} | "
-        f"Score {result.score}/100 | {now.strftime('%b %d')}"
-    )
-    if result.critical_count > 0:
-        subject = "[SEO CRITICAL] " + subject.split("] ", 1)[-1]
-    email_ok = emailer.send_report(subject, html, text)
-    sheets.append("seo_emails", [
-        now.isoformat(), config.REPORT_EMAIL, subject,
-        "sent" if email_ok else "failed",
-        "" if email_ok else "Check GMAIL credentials",
-        run_id,
-    ])
     try:
+        governance.assert_humaniser_scope("emailer.build_morning_brief")
+        html, text = emailer.build_morning_brief(
+            run_record, findings_dicts, skill_name, result.score,
+            comparison=comparison,
+            forecast=forecast,
+            cycle_progress=cycle_progress,
+            recurring=recurring,
+        )
+        status_icon = "✓" if result.score >= 80 else "⚠" if result.score >= 50 else "✗"
+        subject = (
+            f"[SEO {status_icon}] Skill {skill_id:02d}/23 — {skill_name} | "
+            f"Score {result.score}/100 | {now.strftime('%b %d')}"
+        )
+        if result.critical_count > 0:
+            subject = "[SEO CRITICAL] " + subject.split("] ", 1)[-1]
+        email_ok = emailer.send_report(subject, html, text)
+        sheets.append("seo_emails", [
+            now.isoformat(), config.REPORT_EMAIL, subject,
+            "sent" if email_ok else "failed",
+            "" if email_ok else "Check GMAIL credentials",
+            run_id,
+        ])
         memory.append_email_log({
             "date": now.isoformat(),
             "type": "morning_brief",
@@ -518,12 +526,15 @@ def run() -> None:
             "score": result.score,
         })
     except Exception as e:
-        log.warning("Failed to append email log: %s", e)
+        log.error("Morning brief reporting failed (non-fatal): %s", e)
 
     # ── Dashboard snapshot (after email log is finalized) ─────────────────────
-    issues = memory.load_issues()  # reload — email log now written
-    snapshot = memory.build_dashboard_snapshot(run_record, findings_dicts, scores, issues)
-    log.info("Dashboard snapshot written")
+    try:
+        issues = memory.load_issues()  # reload — email log now written
+        memory.build_dashboard_snapshot(run_record, findings_dicts, scores, issues)
+        log.info("Dashboard snapshot written")
+    except Exception as e:
+        log.error("Dashboard snapshot failed (non-fatal): %s", e)
 
     # ── Save state ───────────────────────────────────────────────────────────
     memory.save_run_state(skill_id, run_id)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://amulyagupta.in/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/about.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/projects.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/experience.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/amulya-gupta.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/contact.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/blog/index.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/blog/post-1-mlops-pipeline.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/blog/post-2-mlops-stack.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/blog/ai-ml-guide-2026.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://amulyagupta.in/privacy.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
## Summary

Three targeted fixes to the SEO autonomous runtime, identified during today's scheduled intelligence review.

### Bug 1 — `NameError: name 'meta' is not defined` in `build_cwv_summary` (`memory.py`)

The function referenced an undefined variable `meta` inside the `if cat == "cwv":` branch. This crashes the runtime whenever a skill produces findings with `category="cwv"`. Affected skills: **Skill 5 (Core Web Vitals)** and **Skill 15 (Page Speed Deep Dive)**.

Run #49 (June 13) failed for this reason. The bug will re-trigger in Cycle 2 when these skills run again.

**Fix:** Removed the dead `if meta:` block. CWV records are already tracked via `result.metadata["cwv_records"]` → the `seo_cwv` Sheets tab in `runtime.py`.

---

### Bug 2 — `build_morning_brief()` and `build_dashboard_snapshot()` not protected (`runtime.py`)

Both calls were outside any try/except. An exception in either would:
- Exit with code 1, failing the GitHub Actions job
- Skip `memory.save_run_state()`, causing the **same skill to re-run the next day** instead of advancing the 23-day rotation

**Fix:** Both calls are now wrapped in separate try/except blocks. Reporting failures are logged as errors but remain non-fatal. `save_run_state()` is guaranteed to run after successful skill execution.

---

### Feature — Issue auto-resolution (`memory.py` + `runtime.py`)

Previously, issues found by a skill would remain `"active"` in `issues.json` indefinitely — even after the underlying problem was fixed. This caused:
- Stale issues inflating the active issue count
- False positives in the dashboard metrics
- PR descriptions containing already-resolved issues

**Fix:** Added `resolve_stale_issues(skill_id, new_findings)` which marks previously active issues from a skill as `"resolved"` when they don't reappear in the skill's next run. Called after `batch_upsert_issues` in the main runtime loop.

---

### Content — Sitemap `<lastmod>` refresh (`sitemap.xml`)

Updated all `<lastmod>` dates from `2026-05-19` to `2026-06-15` to reflect recent SEO platform and content updates. This helps search engines prioritize re-crawling.

---

## Current SEO Status (Cycle 1, Skills 1–11 completed)

| Skill | Score | Critical Issues |
|-------|-------|-----------------|
| 01 Technical Crawl | 100 | 0 |
| 02 Robots/Sitemap | 95 | 0 |
| 03 Canonical/Redirects | 100 | 0 |
| 04 Structured Data | 65 | 0 |
| **05 Core Web Vitals** | **46** | **4** (LCP >4000ms on mobile) |
| 06 Meta Tags | 5 | 0 (20 warnings — title/desc lengths) |
| 07 Internal Linking | 10 | 0 (18 warnings — orphan pages) |
| 08 Content Quality | 58 | 1 (thin content: contact.html) |
| 09 Duplicate Content | 100 | 0 |
| 10 Keyword Optimization | 0 | 0 (20 warnings — keyword gaps) |
| 11 AI Search Readiness | 85 | 0 |

**Priority items for manual attention:**
- LCP on mobile (4 pages above 4000ms threshold) — consider preloading hero images
- Meta titles/descriptions need optimization (several over 60/160 char limits)
- Internal linking needs improvement — most pages have no incoming links from other pages

## Review Checklist
- [ ] Verify `build_cwv_summary` no longer crashes on CWV findings
- [ ] Confirm `save_run_state()` runs even when email delivery fails
- [ ] Check that resolved issues in next skill runs are marked `"resolved"` in issues.json
- [ ] Confirm sitemap lastmod dates are acceptable

> ⚠️ **Human review and manual merge required** — the runtime has no auto-merge authority per governance Hard Stop 2.

> Note: PR #17 from branch `claude/vibrant-maxwell-qyylsr` addresses the same Bug 1 and Bug 2. This PR supersedes it with the additional auto-resolution feature and sitemap update. PR #17 can be closed after this merges.

https://claude.ai/code/session_01SJaQXH5iRZDS8CHK7kKUYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJaQXH5iRZDS8CHK7kKUYo)_